### PR TITLE
New:  Support for Compact PKI

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -27,7 +27,8 @@ type CertificateSpec struct {
 type CertificateStatus struct {
 	State       CertificateState `json:"state,omitempty"`
 	Certificate []byte           `json:"certificate,omitempty" protobuf:"bytes,2,opt,name=certificate"`
-	Ca          []byte           `json:"ca,omitempty" protobuf:"bytes,2,opt,name=certificate"`
+	Token       []byte           `json:"token,omitempty" protobuf:"bytes,2,opt,name=token"`
+	Ca          []byte           `json:"ca,omitempty" protobuf:"bytes,2,opt,name=ca"`
 }
 
 // CertificateState defines the state of the certificate

--- a/certificates/certificates.go
+++ b/certificates/certificates.go
@@ -32,6 +32,8 @@ type CertManager struct {
 	caCertPEM []byte
 	caCert    *x509.Certificate
 
+	smartToken []byte
+
 	certClient *certificateclient.CertificateClient
 }
 
@@ -105,7 +107,7 @@ func (m *CertManager) GetCertPEM() ([]byte, error) {
 	return m.certPEM, nil
 }
 
-// GetCaCert return the privateKey
+// GetCaCert returns the privateKey
 func (m *CertManager) GetCaCert() (*x509.Certificate, error) {
 	if m.caCert == nil {
 		return nil, fmt.Errorf("Cert is not received yet")
@@ -114,13 +116,22 @@ func (m *CertManager) GetCaCert() (*x509.Certificate, error) {
 	return m.caCert, nil
 }
 
-// GetCaCertPEM return the privateKey in PEM format
+// GetCaCertPEM returns the privateKey in PEM format
 func (m *CertManager) GetCaCertPEM() ([]byte, error) {
 	if m.caCertPEM == nil {
 		return nil, fmt.Errorf("Cert is not received yet")
 	}
 
 	return m.caCertPEM, nil
+}
+
+// GetSmartToken returns the GetSmartToken
+func (m *CertManager) GetSmartToken() ([]byte, error) {
+	if m.smartToken == nil {
+		return nil, fmt.Errorf("SmartToken is not received yet")
+	}
+
+	return m.smartToken, nil
 }
 
 // SendAndWaitforCert is a blocking func that issue the CertificateRequest and
@@ -182,6 +193,8 @@ func (m *CertManager) SendAndWaitforCert(timeout time.Duration) error {
 				if err != nil {
 					return fmt.Errorf("Couldn't parse CA certificate %s", err)
 				}
+
+				m.smartToken = cert.Status.Token
 
 				return nil
 			}

--- a/certificates/issuer.go
+++ b/certificates/issuer.go
@@ -18,6 +18,7 @@ import (
 type Issuer interface {
 	Validate(csr *x509.CertificateRequest) error
 	Sign(csr *x509.CertificateRequest) ([]byte, error)
+	IssueToken(cert *x509.Certificate) ([]byte, error)
 	GetCACert() []byte
 }
 

--- a/certificates/issuer.go
+++ b/certificates/issuer.go
@@ -3,6 +3,7 @@ package certificates
 import (
 	"bytes"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/aporeto-inc/tg/tglib"
+	"github.com/aporeto-inc/trireme/enforcer/utils/pkiverifier"
 )
 
 // Issuer is able to validate and sign certificates baed on a CSR.
@@ -24,16 +26,22 @@ type TriremeIssuer struct {
 	signingCert    *x509.Certificate
 	signingCertPEM []byte
 	signingKey     crypto.PrivateKey
+
+	tokenIssuer *pkiverifier.PKIConfiguration
 }
 
 // NewTriremeIssuer creates an issuer based on crypto CA objects
 // TODO: Remove the double reference to the SigningCert.
 func NewTriremeIssuer(signingCertPEM []byte, signingCert *x509.Certificate, signingKey crypto.PrivateKey, signingKeyPass string) (*TriremeIssuer, error) {
+	// TODO: Bettre validation of parameters here.
+	triremePKIConfig := pkiverifier.NewConfig(signingCert.PublicKey.(*ecdsa.PublicKey), signingKey.(*ecdsa.PrivateKey), time.Second)
 
 	return &TriremeIssuer{
 		signingCert:    signingCert,
 		signingCertPEM: signingCertPEM,
 		signingKey:     signingKey,
+
+		tokenIssuer: triremePKIConfig,
 	}, nil
 }
 
@@ -81,6 +89,11 @@ func (i *TriremeIssuer) Sign(csr *x509.CertificateRequest) ([]byte, error) {
 	certificatePem := bytes.TrimSpace(clientCertificate)
 
 	return certificatePem, nil
+}
+
+// IssueToken generates a valid token for the cert given as parameter
+func (i *TriremeIssuer) IssueToken(cert *x509.Certificate) ([]byte, error) {
+	return i.tokenIssuer.CreateTokenFromCertificate(cert)
 }
 
 // GetCACert returns the CA Certificate that is used for this issuer.


### PR DESCRIPTION
This PR introduces the logic to generate a `SmartToken` used by the `Compact PKI` Implementation for Trireme.

From the Issuer side:
- New Type in the `status` CRD (Token)
- Logic to generate the `SmartToken` and add it to the Status

From the Client side:
- Deencapsulate the token upon reception.