### PR TITLE
New: move to Kubernetes client-go 5.0.0

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // CertificateResourcePlural is the ressource name used to get a list of cetts.
@@ -47,4 +48,34 @@ type CertificateList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata"`
 	Items           []Certificate `json:"items"`
+}
+
+// DeepCopyObject returns a copy of the object
+func (c *Certificate) DeepCopyObject() runtime.Object {
+	// TODO: Correct DeepCopy
+	return &Certificate{}
+}
+
+// DeepCopyObject returns a copy of the object
+func (c *CertificateList) DeepCopyObject() runtime.Object {
+	// TODO: Correct DeepCopy
+	return &CertificateList{}
+}
+
+// DeepCopyObject returns a copy of the object
+func (c *CertificateStatus) DeepCopyObject() *CertificateStatus {
+	// TODO: Correct DeepCopy
+	return &CertificateStatus{}
+}
+
+// DeepCopyObject returns a copy of the object
+func (c CertificateState) DeepCopyObject() CertificateState {
+	// TODO: Correct DeepCopy
+	return c
+}
+
+// DeepCopyObject returns a copy of the object
+func (c *CertificateSpec) DeepCopyObject() *CertificateSpec {
+	// TODO: Correct DeepCopy
+	return &CertificateSpec{}
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,12 +11,9 @@ import:
   - pkg/selection
   - pkg/watch
 - package: k8s.io/client-go
-  version: ^4.0.0
+  version: ^5.0.0
   subpackages:
   - kubernetes
-  - pkg/api
-  - pkg/api/v1
-  - pkg/apis/extensions/v1beta1
   - rest
   - tools/cache
   - tools/clientcmd

--- a/version/version.go
+++ b/version/version.go
@@ -4,4 +4,4 @@ package version
 const VERSION = "0.11"
 
 // REVISION is the revision of Trireme-CSR
-const REVISION = "957498eb3c85fea49f12a00e265d6091c1f96f1b"
+const REVISION = "3d8df9f1f4acbe4753b5f2e7b938be122196af09"


### PR DESCRIPTION
This PR moves to Client-go 1.5

Still todo: Autogenerate the DeepCopy methods.