### PR TITLE
WIP: First draft of CA manager for generating CA

### DIFF
--- a/ca/ca.go
+++ b/ca/ca.go
@@ -1,0 +1,108 @@
+package ca
+
+import (
+	"crypto/x509"
+	"io/ioutil"
+	"math/rand"
+	"time"
+
+	"github.com/aporeto-inc/tg/tglib"
+)
+
+const (
+	passwordLength = 32
+)
+
+// CertificateAuthority holds a CA
+type CertificateAuthority struct {
+	Key  []byte
+	Pass string
+	Cert []byte
+}
+
+// LoadCertificateAuthorityFromFiles loads an existing CA from files
+func LoadCertificateAuthorityFromFiles(certPath, keyPath, pass string) (*CertificateAuthority, error) {
+	var err error
+	var cert, key []byte
+	cert, err = ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	key, err = ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	ca := &CertificateAuthority{
+		Key:  key,
+		Cert: cert,
+		Pass: pass,
+	}
+	err = ca.validate()
+	if err != nil {
+		return nil, err
+	}
+	return ca, nil
+}
+
+// NewCertificateAuthority generates a new CA
+func NewCertificateAuthority() (*CertificateAuthority, error) {
+	// generate a random password of `passwordLength` characters which consists of
+	// alphanumeric characters plus a selected set of special characters
+	password := randomPassword()
+
+	certPem, keyPem, err := tglib.IssueCertiticate(nil, nil,
+		tglib.ECPrivateKeyGenerator, nil, nil, nil, nil, nil, nil, nil,
+		"Trireme-CSR CA", nil, nil,
+		time.Now(), time.Now().Add(365*24*time.Hour), x509.KeyUsageCRLSign|x509.KeyUsageCertSign, nil,
+		x509.ECDSAWithSHA384, x509.ECDSA, true, nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+	keyPemEncrypted, err := tglib.EncryptPrivateKey(keyPem, password)
+	if err != nil {
+		return nil, err
+	}
+	ca := &CertificateAuthority{
+		Key:  keyPemEncrypted.Bytes,
+		Cert: certPem.Bytes,
+		Pass: password,
+	}
+	err = ca.validate()
+	if err != nil {
+		return nil, err
+	}
+	return ca, nil
+}
+
+func (ca *CertificateAuthority) validate() error {
+	_, _, err := tglib.ReadCertificate(ca.Cert, ca.Key, ca.Pass)
+	return err
+}
+
+func randomPassword() string {
+	// tribute goes to https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-golang
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_,.<>/?:;{}[]+"
+	const (
+		letterIdxBits = 6                    // 6 bits to represent a letter index
+		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+		letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	)
+	n := passwordLength
+	src := rand.NewSource(time.Now().UnixNano())
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}

--- a/ca/mgr/manager.go
+++ b/ca/mgr/manager.go
@@ -1,0 +1,81 @@
+package manager
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/aporeto-inc/trireme-csr/ca"
+	"github.com/aporeto-inc/trireme-csr/ca/persistor"
+)
+
+// Manager struct
+type Manager struct {
+	lock      sync.Mutex
+	ca        *ca.CertificateAuthority
+	persistor persistor.Interface
+}
+
+// NewManager creates a new CA Manager
+func NewManager(persistor persistor.Interface) (*Manager, error) {
+	if persistor == nil {
+		return nil, fmt.Errorf("must be initialized with CA persistor")
+	}
+	return &Manager{
+		persistor: persistor,
+	}, nil
+}
+
+// IsCALoaded is true if a CA is loaded into the manager
+func (m *Manager) IsCALoaded() bool {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	return m.isCALoaded()
+}
+
+// UnloadCA unloads a loaded CA
+func (m *Manager) UnloadCA() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.ca = nil
+}
+
+// LoadCAFromFiles tries to load a CA from the given certPath, keyPath and key password.
+// It returns with an error if this operation fails or a CA is already loaded.
+func (m *Manager) LoadCAFromFiles(certPath, keyPath, password string) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.isCALoaded() {
+		return fmt.Errorf("CA is already loaded")
+	}
+
+	ca, err := ca.LoadCertificateAuthorityFromFiles(certPath, keyPath, password)
+	if err != nil {
+		return err
+	}
+	m.ca = ca
+	return nil
+}
+
+// GenerateCA tries to generate a CA. It returns an error if this operation fails
+// or a CA is already loaded
+func (m *Manager) GenerateCA() error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	if m.isCALoaded() {
+		return fmt.Errorf("CA is already loaded")
+	}
+
+	ca, err := ca.NewCertificateAuthority()
+	if err != nil {
+		return err
+	}
+	m.ca = ca
+	return nil
+}
+
+// isCALoaded is the internal version of IsCALoaded but just without the lock
+func (m *Manager) isCALoaded() bool {
+	return m.ca != nil
+}

--- a/ca/persistor/kubernetes/converter.go
+++ b/ca/persistor/kubernetes/converter.go
@@ -1,0 +1,29 @@
+package kubernetes
+
+import (
+	"github.com/aporeto-inc/trireme-csr/ca"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	secretCertEntry = "ca-cert.pem"
+	secretKeyEntry  = "ca-key.pem"
+	secretPwEntry   = "ca-pass"
+)
+
+func caToSecret(ca ca.CertificateAuthority, name, namespace string) corev1.Secret {
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			secretKeyEntry:  ca.Key,
+			secretPwEntry:   []byte(ca.Pass),
+			secretCertEntry: ca.Cert,
+		},
+	}
+}

--- a/ca/persistor/kubernetes/secrets_persistor.go
+++ b/ca/persistor/kubernetes/secrets_persistor.go
@@ -1,0 +1,58 @@
+package kubernetes
+
+import (
+	"github.com/aporeto-inc/trireme-csr/ca"
+	"github.com/aporeto-inc/trireme-csr/ca/persistor"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// DefaultCertificateAuthorityName is a good fallback for the secret name
+	DefaultCertificateAuthorityName = "trireme-cacert"
+	// DefaultCertificateAuthorityNamespace is the kubernetes namespace where this secret should be stored
+	DefaultCertificateAuthorityNamespace = "kube-system"
+)
+
+// SecretsPersistor implements the CA persistor interface
+// and persists a CA to a Kubernetes secret
+type SecretsPersistor struct {
+	client    *kubernetes.Clientset
+	name      string
+	namespace string
+}
+
+// NewSecretsPersistor creates a new CA Kubernetes Secrets Persistor
+func NewSecretsPersistor(client *kubernetes.Clientset, name, namespace string) persistor.Interface {
+	return &SecretsPersistor{
+		client:    client,
+		name:      name,
+		namespace: namespace,
+	}
+}
+
+// Store the given CA
+func (p *SecretsPersistor) Store(ca ca.CertificateAuthority) error {
+	newSecret := caToSecret(ca, p.name, p.namespace)
+	_, err := p.client.CoreV1().Secrets(p.namespace).Create(&newSecret)
+	return err
+}
+
+// Delete the stored CA
+func (p *SecretsPersistor) Delete() error {
+	return p.client.CoreV1().Secrets(p.namespace).Delete(p.name, &metav1.DeleteOptions{})
+}
+
+// Overwrite the stored CA
+func (p *SecretsPersistor) Overwrite(ca ca.CertificateAuthority) error {
+	newSecret := caToSecret(ca, p.name, p.namespace)
+	_, err := p.client.CoreV1().Secrets(p.namespace).Update(&newSecret)
+	return err
+}
+
+// Exists returns true if there is a CA stored
+func (p *SecretsPersistor) Exists() bool {
+	_, err := p.client.CoreV1().Secrets(p.namespace).Get(p.name, metav1.GetOptions{})
+	return err == nil
+}

--- a/ca/persistor/persistor.go
+++ b/ca/persistor/persistor.go
@@ -1,0 +1,15 @@
+package persistor
+
+import "github.com/aporeto-inc/trireme-csr/ca"
+
+// Interface describes the CA persistor interface
+type Interface interface {
+	// Store the given CA
+	Store(ca ca.CertificateAuthority) error
+	// Delete the stored CA
+	Delete() error
+	// Overwrite the stored CA
+	Overwrite(ca ca.CertificateAuthority) error
+	// Exists returns true if there is a CA stored
+	Exists() bool
+}

--- a/cmd/CAManager/kubernetes.go
+++ b/cmd/CAManager/kubernetes.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func newKubeClient() (*kubernetes.Clientset, error) {
+	var err error
+	var config *rest.Config
+	var clientset *kubernetes.Clientset
+
+	kubeconfig := os.Getenv("HOME") + "/.kube/config"
+	_, err = os.Stat(kubeconfig)
+	if err != nil && os.IsNotExist(err) {
+		zap.L().Debug("trying to use InClusterConfig()")
+		// try using cluster-internal config
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		zap.L().Debug("trying to use out-of-the cluster configuration", zap.String("kubeconfig", kubeconfig))
+
+		// try using provided config for cluster-external config
+		// uses the current context in kubeconfig
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// creates the clientset
+	zap.L().Debug("trying to create clientset now from config")
+	clientset, err = kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return clientset, nil
+}

--- a/cmd/CAManager/main.go
+++ b/cmd/CAManager/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"go.uber.org/zap"
+
+	camgr "github.com/aporeto-inc/trireme-csr/ca/mgr"
+	kubepersistor "github.com/aporeto-inc/trireme-csr/ca/persistor/kubernetes"
+)
+
+func main() {
+	setLogs("info")
+
+	kubeclient, err := newKubeClient()
+	if err != nil {
+		zap.L().Fatal("failed to create kubernetes client", zap.Error(err))
+	}
+
+	persistor := kubepersistor.NewSecretsPersistor(
+		kubeclient,
+		kubepersistor.DefaultCertificateAuthorityName,
+		kubepersistor.DefaultCertificateAuthorityNamespace,
+	)
+
+	mgr, err := camgr.NewManager(persistor)
+	if err != nil {
+		zap.L().Fatal("failed to create CA Manager", zap.Error(err))
+	}
+
+	mgr.GenerateCA()
+}
+
+// setLogs setups Zap to the specified logLevel.
+func setLogs(logLevel string) error {
+	zapConfig := zap.NewDevelopmentConfig()
+	zapConfig.DisableStacktrace = true
+
+	// Set the logger
+	switch logLevel {
+	case "trace":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	case "debug":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+	case "info":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	case "warn":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.WarnLevel)
+	case "error":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.ErrorLevel)
+	case "fatal":
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.FatalLevel)
+	default:
+		zapConfig.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
+	}
+
+	logger, err := zapConfig.Build()
+	if err != nil {
+		return err
+	}
+
+	zap.ReplaceGlobals(logger)
+	return nil
+}


### PR DESCRIPTION
Still WIP.

It's an initialization utility for generating a CA and storing it in Kubernetes (a Kubernetes Secret). The tool will have the ability to load an existing CA, as well as delete and update a CA. Furthermore the persistor is an interface, and has only one implementation so far: Kubernetes Secrets. As @bvandewalle and myself are not so certain if that is the right approach, I thought I'll make this pluggable. 

Fixes #16 .